### PR TITLE
Adding addCssClassNames to table leaf

### DIFF
--- a/src/Leaves/Table.php
+++ b/src/Leaves/Table.php
@@ -390,16 +390,13 @@ class Table extends Leaf
         $this->model->searched = true;
     }
 
+    /**
+     * @deprecated 
+     * @see addCssClassNames
+     */
     public function addTableCssClass($classNames)
     {
-        $classes = $this->model->tableCssClassNames;
-
-        if (!is_array($classes)) {
-            $classes = [];
-        }
-
-        $classes = array_merge($classes, $classNames);
-        $this->tableCssClassNames = $classes;
+        $this->addCssClassNames($classNames);
     }
 
     protected function beforeRender()

--- a/src/Leaves/TableModel.php
+++ b/src/Leaves/TableModel.php
@@ -52,11 +52,6 @@ class TableModel extends LeafModel
     public $footerProviders = [];
 
     /**
-     * @var string[]    An array of css class names for the table
-     */
-    public $tableCssClassNames = [];
-
-    /**
      * @var string The name of the column being used for sorting
      */
     public $sortColumn;

--- a/src/Leaves/TableView.php
+++ b/src/Leaves/TableView.php
@@ -82,7 +82,7 @@ class TableView extends View
 
         ?>
         <div class='list'>
-            <table class="<?= $this->getTableCssClass(); ?>">
+            <table<?= $this->model->getClassAttribute(); ?>>
                 <thead>
                 <tr>
                     <?php


### PR DESCRIPTION
Table had its own function to add css classes which is no longer needed since we added a function to the base leaf in - https://github.com/RhubarbPHP/Module.Leaf/pull/27
